### PR TITLE
docs(banner): fix svg banner on npmjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://baloise-ui-library.now.sh" target="blank">
-    <img src="src/docs/assets/images/banner.svg" width="500" alt="Baloise UI-Library" />
+    <img src="src/docs/assets/images/banner.svg?sanitize=true" width="500" alt="Baloise UI-Library" />
 </a>
 
 <br><br>


### PR DESCRIPTION
The banner svg is not displayed on [npmjs](https://www.npmjs.com/package/@baloise/ui-library).
It seems like adding `?sanitize=true` to the url solves the problem:
https://raw.githubusercontent.com/baloise/ui-library/HEAD/src/docs/assets/images/banner.svg
https://raw.githubusercontent.com/baloise/ui-library/HEAD/src/docs/assets/images/banner.svg?sanitize=true