### PR TITLE
fix navbar mobile menu toggle and styling

### DIFF
--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,35 +1,44 @@
-import {Element, Component, Host, h, Prop, State} from "@stencil/core";
+import { Component, Element, h, Host, Prop, State } from '@stencil/core'
 
 @Component({
-  tag: "bal-navbar",
-  styleUrl: "navbar.scss",
+  tag: 'bal-navbar',
+  styleUrl: 'navbar.scss',
 })
 export class Navbar {
 
-  hasNavbarStartSlot: boolean;
-  hasNavbarEndSlot: boolean;
+  hasNavbarStartSlot: boolean
+  hasNavbarEndSlot: boolean
 
-  @State() isMenuActive: boolean = false;
+  @State() isMenuActive: boolean = false
 
-  @Prop() light = false;
-  @Prop() logoHref = "https://bulma.io";
+  @Prop() light = false
+  @Prop() logoHref = ''
 
-  @Element() el: HTMLElement;;
+  @Element() el: HTMLElement
+;
 
   componentWillLoad() {
-    this.hasNavbarStartSlot = !!this.el.querySelector('[slot="navbar-start"]');
-    this.hasNavbarEndSlot = !!this.el.querySelector('[slot="navbar-end"]');
+    this.hasNavbarStartSlot = !!this.el.querySelector('[slot="navbar-start"]')
+    this.hasNavbarEndSlot = !!this.el.querySelector('[slot="navbar-end"]')
   }
 
   async toggle(): Promise<void> {
-    this.isMenuActive = !this.isMenuActive;
+    this.isMenuActive = !this.isMenuActive
   }
 
   render() {
     return (
       <Host>
-        <nav class={ "navbar is-spaced" + (this.light ? " is-white bal-track-line" : " is-info") }
-             role="navigation" aria-label="main navigation">
+        <nav class={'navbar is-spaced' + (this.light ? ' is-white' : ' is-info')}
+             role="navigation"
+             aria-label="main navigation">
+          <div class="bal-track-line"
+               style={{
+                 position: 'absolute',
+                 top: '0',
+                 left: '0',
+                 display: !this.light ? 'none' : '',
+               }}></div>
           <div class="navbar-brand">
             <a class="navbar-item app-title"
                href={this.logoHref}>
@@ -37,17 +46,17 @@ export class Navbar {
             </a>
             {this.hasNavbarStartSlot || this.hasNavbarEndSlot ?
               <a role="button"
-                 class={ "navbar-burger" + (this.isMenuActive ? " is-active" : "") }
+                 class={'navbar-burger' + (this.isMenuActive ? ' is-active' : '')}
                  aria-label="menu"
-                 aria-expanded={ this.isMenuActive ? "true" : "false" }
-                 onClick={ () => this.toggle() }>
+                 aria-expanded={this.isMenuActive ? 'true' : 'false'}
+                 onClick={() => this.toggle()}>
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
               </a>
-            : ""}
+              : ''}
           </div>
-          <div class={ "navbar-menu" + (this.isMenuActive ? " is-active" : "") }>
+          <div class={'navbar-menu' + (this.isMenuActive ? ' is-active' : '')}>
             <div class="navbar-start">
               <slot name="navbar-start"/>
             </div>
@@ -57,7 +66,7 @@ export class Navbar {
           </div>
         </nav>
       </Host>
-    );
+    )
   }
 
 }

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,4 +1,4 @@
-import {Element, Component, Host, h, Prop} from "@stencil/core";
+import {Element, Component, Host, h, Prop, State} from "@stencil/core";
 
 @Component({
   tag: "bal-navbar",
@@ -8,6 +8,8 @@ export class Navbar {
 
   hasNavbarStartSlot: boolean;
   hasNavbarEndSlot: boolean;
+
+  @State() isMenuActive: boolean = false;
 
   @Prop() light = false;
   @Prop() logoHref = "https://bulma.io";
@@ -19,27 +21,33 @@ export class Navbar {
     this.hasNavbarEndSlot = !!this.el.querySelector('[slot="navbar-end"]');
   }
 
+  async toggle(): Promise<void> {
+    this.isMenuActive = !this.isMenuActive;
+  }
+
   render() {
     return (
       <Host>
-        <nav class={[
-          "navbar is-spaced bal-track-line",
-          this.light ? "is-white" : "is-info",
-        ].join(" ")} role="navigation" aria-label="main navigation">
+        <nav class={ "navbar is-spaced" + (this.light ? " is-white bal-track-line" : " is-info") }
+             role="navigation" aria-label="main navigation">
           <div class="navbar-brand">
             <a class="navbar-item app-title"
                href={this.logoHref}>
               <slot name="navbar-brand"/>
             </a>
             {this.hasNavbarStartSlot || this.hasNavbarEndSlot ?
-              <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false">
+              <a role="button"
+                 class={ "navbar-burger" + (this.isMenuActive ? " is-active" : "") }
+                 aria-label="menu"
+                 aria-expanded={ this.isMenuActive ? "true" : "false" }
+                 onClick={ () => this.toggle() }>
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
                 <span aria-hidden="true"></span>
               </a>
             : ""}
           </div>
-          <div class="navbar-menu">
+          <div class={ "navbar-menu" + (this.isMenuActive ? " is-active" : "") }>
             <div class="navbar-start">
               <slot name="navbar-start"/>
             </div>

--- a/src/components/navbar/readme.md
+++ b/src/components/navbar/readme.md
@@ -70,10 +70,10 @@ A responsive horizontal navbar that can support images, links, buttons, and drop
 
 ## Properties
 
-| Property   | Attribute   | Description | Type      | Default              |
-| ---------- | ----------- | ----------- | --------- | -------------------- |
-| `light`    | `light`     |             | `boolean` | `false`              |
-| `logoHref` | `logo-href` |             | `string`  | `"https://bulma.io"` |
+| Property   | Attribute   | Description | Type      | Default |
+| ---------- | ----------- | ----------- | --------- | ------- |
+| `light`    | `light`     |             | `boolean` | `false` |
+| `logoHref` | `logo-href` |             | `string`  | `''`    |
 
 
 ----------------------------------------------

--- a/src/scss/components/navbar.scss
+++ b/src/scss/components/navbar.scss
@@ -9,7 +9,7 @@ $navbar-padding-horizontal: 3.75rem;
 $navbar-z: 30;
 $navbar-fixed-z: 30;
 
-$navbar-item-color: red;
+$navbar-item-color: $white;
 $navbar-item-hover-color: $link;
 $navbar-item-hover-background-color: $scheme-main-bis;
 $navbar-item-active-color: $scheme-invert;
@@ -35,7 +35,7 @@ $navbar-dropdown-z: 20;
 
 $navbar-dropdown-boxed-radius: $radius-large;
 $navbar-dropdown-boxed-shadow: 0 8px 8px rgba($scheme-invert, 0.1),
-  0 0 0 1px rgba($scheme-invert, 0.1);
+0 0 0 1px rgba($scheme-invert, 0.1);
 
 $navbar-dropdown-item-hover-color: $scheme-invert;
 $navbar-dropdown-item-hover-background-color: $background;
@@ -65,10 +65,6 @@ $navbar-breakpoint: $desktop;
     background: $blue !important;
   }
 
-  .navbar-start {
-    margin-left: 15px;
-  }
-
   .app-title span {
     font-size: $size-3;
     color: $blue;
@@ -76,6 +72,12 @@ $navbar-breakpoint: $desktop;
 
   &.is-info .app-title span {
     color: $white;
+  }
+
+  .navbar-menu.is-active {
+    .navbar-item {
+      color: $blue;
+    }
   }
 
   .navbar-item img {

--- a/src/scss/components/navbar.scss
+++ b/src/scss/components/navbar.scss
@@ -9,7 +9,7 @@ $navbar-padding-horizontal: 3.75rem;
 $navbar-z: 30;
 $navbar-fixed-z: 30;
 
-$navbar-item-color: $white;
+$navbar-item-color: red;
 $navbar-item-hover-color: $link;
 $navbar-item-hover-background-color: $scheme-main-bis;
 $navbar-item-active-color: $scheme-invert;

--- a/src/scss/elements/input.scss
+++ b/src/scss/elements/input.scss
@@ -55,7 +55,7 @@ textarea.textarea {
     }
 
     &::-webkit-input-placeholder {
-      color: $blue-light-line;
+      color: $blue-light-text;
     }
   }
 }


### PR DESCRIPTION
Fixes #161 

(includes unmerged changes of PR #159 and #160)

There are still two open issues:
1. `bal-track-line` breaks the mobile menu + burger location (see header in light mode)
2. menu item colors are not styled correctly (see navbar.scss)