### PR TITLE
feat(button): fix loading spinner for link and outlined

### DIFF
--- a/packages/library/src/components/bal-button/bal-button.tsx
+++ b/packages/library/src/components/bal-button/bal-button.tsx
@@ -187,6 +187,13 @@ export class Button implements ComponentInterface {
     }
   }
 
+  private get spinnerCssClass() {
+    return {
+      'is-small': true,
+      'is-inverted': !(this.color === 'link' || this.outlined),
+    }
+  }
+
   private get iconSize() {
     if (this.size === 'small') {
       return 'xsmall'
@@ -275,7 +282,7 @@ export class Button implements ComponentInterface {
       >
         <TagType {...attrs} type={this.type} class={this.buttonCssClass} part="native" disabled={this.disabled} onFocus={this.onFocus} onBlur={this.onBlur} onClick={this.onClick}>
           <span {...this.spanAttrs}>{/* Empty span to get the correct text height */}</span>
-          <bal-spinner {...this.loadingAttrs} class="is-small is-inverted" />
+          <bal-spinner {...this.loadingAttrs} class={this.spinnerCssClass} />
           <bal-icon {...this.leftIconAttrs} class="icon-left" name={this.icon} size={this.square ? this.size : this.iconSize} color={this.color} inverted={this.isIconInverted} />
           <bal-text {...this.spanAttrs} small={this.size === 'small'} style={{ display: this.loading ? 'none' : 'inline' }}>
             <slot />

--- a/packages/library/src/components/bal-button/index.html
+++ b/packages/library/src/components/bal-button/index.html
@@ -63,6 +63,8 @@
       <section>
         <bal-button color="primary" loading>Primary</bal-button>
         <bal-button color="info" loading>Info</bal-button>
+        <bal-button color="link" loading>Info</bal-button>
+        <bal-button color="primary" loading outlined>Info</bal-button>
       </section>
 
       <h2 class="title is-size-2">Expanded</h2>


### PR DESCRIPTION
Loading spinner are inverted for link and outlined and not visible anymore.
This PR fixes this.