### PR TITLE
chore(angular): added Content Security Policy

### DIFF
--- a/examples/angular/src/index.html
+++ b/examples/angular/src/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src *;" />
     <title>BalApp</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
We are facing inline style content violation, bellow is related error message:

```
Refused to apply inline style because it violates the following Content
Security Policy directive: "default-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-Sm75wB15wFFN/gRy3Q1zno79of9hUn4BmR/i+0LidSU='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'style-src' was not explicitly set, so 'default-src' is used as a fallback.
```

Notice that:
> The issue happened since `@baloise/ui-library:4.8.0`

**Changed**

- Added CSP content: `default-src 'self'; img-src *;` to example for angular project to verify CSP violation.
