### PR TITLE
docs: remove pipes module from instructions where it has not been ins…

### DIFF
--- a/packages/components/src/stories/getting-started/angular/01-installation.stories.mdx
+++ b/packages/components/src/stories/getting-started/angular/01-installation.stories.mdx
@@ -78,14 +78,13 @@ Import the `BaloiseDesignSystemModule` and add it to your angular module. To use
 ```typescript
 import { BrowserModule } from '@angular/platform-browser'
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
-import { BaloisePipeModule } from '@baloise/web-app-pipes-angular'
 import { BaloiseDesignSystemModule } from '@baloise/design-system-components-angular'
 
 import { AppComponent } from './app.component'
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, BaloisePipeModule, BaloiseDesignSystemModule.forRoot()],
+  imports: [BrowserModule, BaloiseDesignSystemModule.forRoot()],
   providers: [],
   bootstrap: [AppComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],


### PR DESCRIPTION
The Pipes Module has not been installed at this point.
It has a separate section in the docs, so no need to import it here I think.