### PR TITLE
fix(footer): the footer links will only load for CH regions

### DIFF
--- a/packages/components/src/components/bal-footer/bal-footer.tsx
+++ b/packages/components/src/components/bal-footer/bal-footer.tsx
@@ -8,7 +8,7 @@ import {
   detachComponentToConfig,
   attachComponentToConfig,
   updateBalLanguage,
-  useBalConfig,
+  BalRegion,
 } from '../../config'
 
 @Component({
@@ -17,6 +17,7 @@ import {
 export class Footer implements BalConfigObserver {
   @State() links: FooterLink[] = []
   @State() language: BalLanguage = defaultConfig.language
+  @State() region: BalRegion = defaultConfig.region
   @State() allowedLanguages: BalLanguage[] = defaultConfig.allowedLanguages
 
   /**
@@ -50,6 +51,7 @@ export class Footer implements BalConfigObserver {
 
   configChanged(config: BalConfigState) {
     this.language = config.language
+    this.region = config.region
     this.allowedLanguages = config.allowedLanguages
     this.updateFooterLinks()
   }
@@ -67,12 +69,9 @@ export class Footer implements BalConfigObserver {
   }
 
   updateFooterLinks() {
-    if (!this.hideLinks) {
-      const config = useBalConfig()
-      if (config?.region === 'CH') {
-        // The following footer links only apply to swiss applications
-        loadFooterLinks(new Language(this.language)).then(links => (this.links = links))
-      }
+    if (!this.hideLinks && this.region === 'CH') {
+      // The following footer links only apply to swiss applications
+      loadFooterLinks(new Language(this.language)).then(links => (this.links = links))
     }
   }
 

--- a/packages/components/src/components/bal-footer/bal-footer.tsx
+++ b/packages/components/src/components/bal-footer/bal-footer.tsx
@@ -8,6 +8,7 @@ import {
   detachComponentToConfig,
   attachComponentToConfig,
   updateBalLanguage,
+  useBalConfig,
 } from '../../config'
 
 @Component({
@@ -67,7 +68,11 @@ export class Footer implements BalConfigObserver {
 
   updateFooterLinks() {
     if (!this.hideLinks) {
-      loadFooterLinks(new Language(this.language)).then(links => (this.links = links))
+      const config = useBalConfig()
+      if (config?.region === 'CH') {
+        // The following footer links only apply to swiss applications
+        loadFooterLinks(new Language(this.language)).then(links => (this.links = links))
+      }
     }
   }
 


### PR DESCRIPTION
Until now, the footer links in the footer component were loaded for all regions in the DS config.
With this change, the links will only be loaded for CH applications (region in the DS config is set to CH).
