### PR TITLE
fix(bal-input): contract has now 10 digits and for contacts with 9 di…

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -831,7 +831,7 @@ export namespace Components {
          */
         "inverted": boolean;
         /**
-          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted. Formatting for 'contract-number': '00/0.000.000' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321')
+          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321')
          */
         "mask"?: Props.BalInputMask;
         /**
@@ -3316,7 +3316,7 @@ declare namespace LocalJSX {
          */
         "inverted"?: boolean;
         /**
-          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted. Formatting for 'contract-number': '00/0.000.000' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321')
+          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321')
          */
         "mask"?: Props.BalInputMask;
         /**

--- a/packages/components/src/components/form/bal-input/bal-input-util.ts
+++ b/packages/components/src/components/form/bal-input/bal-input-util.ts
@@ -30,7 +30,7 @@ export function formatClaim(value: string): string {
 /**
  *
  * @param value: input number
- * @output 00/0.000.000
+ * @output 99/1.234.567-1
  * @private
  */
 export function formatPolicy(value: string): string {
@@ -38,10 +38,10 @@ export function formatPolicy(value: string): string {
     return ''
   }
   let newValue = `${value}`.trim()
-  if (newValue[0] !== '0') {
-    newValue = `0${value}`
-  }
-  return formatOffer(newValue)
+  const parts = [newValue.substring(0, 9), newValue.substring(9, 10)].filter(val => val.length > 0)
+  newValue = formatOffer(parts[0])
+
+  return parts[1] ? `${newValue}-${parts[1]}` : newValue
 }
 
 /**
@@ -72,6 +72,6 @@ export function formatOffer(value: string): string {
       return `${parts[0]}/${parts[1]}.${parts[2]}.${parts[3]}`
   }
 }
-export const MAX_LENGTH_CONTRACT_NUMBER = 9
+export const MAX_LENGTH_CONTRACT_NUMBER = 10
 export const MAX_LENGTH_OFFER_NUMBER = 9
 export const MAX_LENGTH_CLAIM_NUMBER = 11

--- a/packages/components/src/components/form/bal-input/bal-input.tsx
+++ b/packages/components/src/components/form/bal-input/bal-input.tsx
@@ -218,7 +218,7 @@ export class Input implements ComponentInterface, FormInput<string | undefined> 
 
   /**
    * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted.
-   * Formatting for 'contract-number': '00/0.000.000'
+   * Formatting for 'contract-number': '99/1.234.567-1'
    * Formatting for 'claim-number': ('73/001217/16.9')
    * Formatting for 'offer-number': ('98/7.654.321')
    */

--- a/packages/components/src/components/form/bal-input/test/bal-input-util.spec.ts
+++ b/packages/components/src/components/form/bal-input/test/bal-input-util.spec.ts
@@ -59,8 +59,8 @@ describe('bal-input-util testing:', () => {
   })
   describe('formatPolicy', () => {
     test('full entry:', () => {
-      const result = formatPolicy('98765432')
-      expect(result).toStrictEqual('09/8.765.432')
+      const result = formatPolicy('9087654321')
+      expect(result).toStrictEqual('90/8.765.432-1')
     })
     test('empty:', () => {
       const result = formatPolicy('')
@@ -70,13 +70,13 @@ describe('bal-input-util testing:', () => {
       const result = formatPolicy('098765432')
       expect(result).toStrictEqual('09/8.765.432')
     })
-    test('9 characters without starting 0:', () => {
+    test('9 characters:', () => {
       const result = formatPolicy('987654327')
-      expect(result).toStrictEqual('09/8.765.432')
+      expect(result).toStrictEqual('98/7.654.327')
     })
-    test('10 characters without starting 0:', () => {
-      const result = formatPolicy('0987654327')
-      expect(result).toStrictEqual('09/8.765.432')
+    test('11 characters', () => {
+      const result = formatPolicy('90876543278')
+      expect(result).toStrictEqual('90/8.765.432-7')
     })
   })
 })


### PR DESCRIPTION
…gits use offer-number mask

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
