### PR TITLE
fix(modal): remove promise rejection when no overlay exists bc promis…

### DIFF
--- a/packages/components/src/components/notice/bal-modal/bal-modal.controller.ts
+++ b/packages/components/src/components/notice/bal-modal/bal-modal.controller.ts
@@ -26,9 +26,6 @@ export class BalModalController {
 
   async dismissAll(data?: any, role?: string): Promise<void> {
     const overlays = getOverlays(document, this.tag)
-    if (overlays.length < 1) {
-      return Promise.reject('overlay does not exist')
-    }
     await Promise.all(overlays.map(o => o.dismiss(data, role)))
   }
 


### PR DESCRIPTION
This PR removes the promise rejection of the dismissAll function when no overlay exists. A rejected promise should only be returned when the close/dismiss of an existing overlay fails, Otherwise every consumer of this functionality needs to implement a catch mechanism for the "overlay does not exist" case.

#### Changelog

**Removed**

- remove promise rejection of dismissAll function when no overlay exists 
