### PR TITLE
fix(components-react): Typo in Homepage

### DIFF
--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/baloise/design-system.git"
   },
-  "homepage": "https://design.baloise.dev.sh",
+  "homepage": "https://design.baloise.dev",
   "contributors": [
     "Gery Hirschfeld <gerhard.hirschfeld@baloise.ch> (https://github.com/hirsch88)",
     "Yannick Holzenkamp <yannick.holzenkamp@baloise.ch> (https://github.com/yannickholzenkamp)",


### PR DESCRIPTION
The typo in the package.json leads to incorrect urls when using tools like npm-check

#### Changelog

**Changed**

- components-react: Homepage

