### PR TITLE
✨ feat(input): removing leading zero from contracts/subcontracts 

### DIFF
--- a/.changeset/purple-islands-breathe.md
+++ b/.changeset/purple-islands-breathe.md
@@ -1,5 +1,5 @@
 ---
-'@baloise/ds-core': patch
+'@baloise/ds-core': minor
 ---
 
-**core**: New mask for bal-input: Basic contract mask. Removal of leading zero for contract and basic contract mask.
+**input**: added basic contract mask and removal of leading zero for contract and basic contract mask.

--- a/.changeset/purple-islands-breathe.md
+++ b/.changeset/purple-islands-breathe.md
@@ -1,0 +1,5 @@
+---
+'@baloise/ds-core': patch
+---
+
+**core**: New mask for bal-input: Basic contract mask. Removal of leading zero for contract and basic contract mask.

--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -1431,7 +1431,7 @@ export namespace Components {
          */
         "invalid": boolean;
         /**
-          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321') Formatting for 'be-enterprise-number': ('1234.567.890') Formatting for 'be-iban': ('BE68 5390 0754 7034')
+          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'basic-contract-number': '99/1.234.567' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321') Formatting for 'be-enterprise-number': ('1234.567.890') Formatting for 'be-iban': ('BE68 5390 0754 7034')
          */
         "mask"?: BalProps.BalInputMask;
         /**
@@ -6580,7 +6580,7 @@ declare namespace LocalJSX {
          */
         "invalid"?: boolean;
         /**
-          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321') Formatting for 'be-enterprise-number': ('1234.567.890') Formatting for 'be-iban': ('BE68 5390 0754 7034')
+          * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN. Formatting for 'contract-number': '99/1.234.567-1' Formatting for 'basic-contract-number': '99/1.234.567' Formatting for 'claim-number': ('73/001217/16.9') Formatting for 'offer-number': ('98/7.654.321') Formatting for 'be-enterprise-number': ('1234.567.890') Formatting for 'be-iban': ('BE68 5390 0754 7034')
          */
         "mask"?: BalProps.BalInputMask;
         /**

--- a/packages/core/src/components/bal-input/bal-input-util.ts
+++ b/packages/core/src/components/bal-input/bal-input-util.ts
@@ -127,6 +127,7 @@ export function formatBeIBAN(value: string): string {
 }
 
 export const MAX_LENGTH_CONTRACT_NUMBER = 10
+export const MAX_LENGTH_BASIC_CONTRACT_NUMBER = 9
 export const MAX_LENGTH_OFFER_NUMBER = 9
 export const MAX_LENGTH_CLAIM_NUMBER = 11
 export const MAX_LENGTH_BE_ENTERPRISE_NUMBER = 10

--- a/packages/core/src/components/bal-input/bal-input.interfaces.ts
+++ b/packages/core/src/components/bal-input/bal-input.interfaces.ts
@@ -6,7 +6,13 @@
 namespace BalProps {
   export type BalInputAutocorrect = 'on' | 'off'
   export type BalInputInputMode = 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search'
-  export type BalInputMask = 'contract-number' | 'claim-number' | 'offer-number' | 'be-enterprise-number' | 'be-iban'
+  export type BalInputMask =
+    | 'contract-number'
+    | 'basic-contract-number'
+    | 'claim-number'
+    | 'offer-number'
+    | 'be-enterprise-number'
+    | 'be-iban'
   // From: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
   export type BalInputInputType =
     | 'button'

--- a/packages/core/src/components/bal-input/bal-input.tsx
+++ b/packages/core/src/components/bal-input/bal-input.tsx
@@ -39,6 +39,7 @@ import {
   MAX_LENGTH_CLAIM_NUMBER,
   MAX_LENGTH_CONTRACT_NUMBER,
   MAX_LENGTH_OFFER_NUMBER,
+  MAX_LENGTH_BASIC_CONTRACT_NUMBER,
 } from './bal-input-util'
 import isNil from 'lodash.isnil'
 import { ACTION_KEYS, isCtrlOrCommandKey, NUMBER_KEYS } from '../../utils/constants/keys.constant'
@@ -217,6 +218,7 @@ export class Input implements ComponentInterface, FormInput<string | undefined>,
   /**
    * Mask of the input field. It defines what the user can enter and how the format looks like. Currently, only for Switzerland formatted with addition of Belgian enterprisenumber and IBAN.
    * Formatting for 'contract-number': '99/1.234.567-1'
+   * Formatting for 'basic-contract-number': '99/1.234.567'
    * Formatting for 'claim-number': ('73/001217/16.9')
    * Formatting for 'offer-number': ('98/7.654.321')
    * Formatting for 'be-enterprise-number': ('1234.567.890')
@@ -348,8 +350,23 @@ export class Input implements ComponentInterface, FormInput<string | undefined>,
           switch (this.mask) {
             case 'contract-number': {
               inputValue = input.value.replace(/\D/g, '')
+              // Removing the leading zero if presented
+              if (inputValue.charAt(0) === '0') {
+                inputValue = inputValue.substring(1)
+              }
               if (inputValue.length > MAX_LENGTH_CONTRACT_NUMBER) {
                 inputValue = inputValue.substring(0, MAX_LENGTH_CONTRACT_NUMBER)
+              }
+              return inputValue
+            }
+            case 'basic-contract-number': {
+              inputValue = input.value.replace(/\D/g, '')
+              // Removing the leading zero if presented
+              if (inputValue.charAt(0) === '0') {
+                inputValue = inputValue.substring(1)
+              }
+              if (inputValue.length > MAX_LENGTH_BASIC_CONTRACT_NUMBER) {
+                inputValue = inputValue.substring(0, MAX_LENGTH_BASIC_CONTRACT_NUMBER)
               }
               return inputValue
             }
@@ -418,7 +435,8 @@ export class Input implements ComponentInterface, FormInput<string | undefined>,
     if (input) {
       if (input.value) {
         switch (this.mask) {
-          case 'contract-number': {
+          case 'contract-number':
+          case 'basic-contract-number': {
             input.value = formatPolicy(this.inputValue)
             if (cursorPositionStart < this.inputValue.length) {
               input.setSelectionRange(cursorPositionStart, cursorPositionEnd)
@@ -520,6 +538,7 @@ export class Input implements ComponentInterface, FormInput<string | undefined>,
     if (this.mask !== undefined) {
       switch (this.mask) {
         case 'contract-number':
+        case 'basic-contract-number':
           value = formatPolicy(value)
           break
         case 'claim-number':

--- a/packages/core/src/components/bal-input/test/bal-input.cy.html
+++ b/packages/core/src/components/bal-input/test/bal-input.cy.html
@@ -37,6 +37,8 @@
         <section>
           <bal-input mask="claim-number" value="7300772816x"></bal-input>
           <bal-input mask="claim-number"></bal-input>
+          <bal-input mask="contract-number" value="9069998881"></bal-input>
+          <bal-input mask="basic-contract-number" value="906999888"></bal-input>
         </section>
       </main>
     </bal-doc-app>


### PR DESCRIPTION
New mask: basic-contract-number: Trims contract number to 9 instead of 10 characters preventing input of subcontract number.
Removing a leading zero from contract-number and basic-contract-number masks.


## Acceptance Criteria

- Design & Technical Review
  - [Style Guide](https://stenciljs.com/docs/style-guide)
- Document changes with a changeset
- Testing
  - Visual
  - Functional (component test)
  - Browser
    - Desktop
      - Chrome
      - Edge
      - Safari
      - Firefox
    - Tablet
      - iPad (Landscape / Portrait)
    - Mobile
      - Safari iOS
      - Chrome Preview
