### PR TITLE
fix(packages/react): Add @stencil/react-output-target to the dependen…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7185,7 +7185,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
       "integrity": "sha512-cencnwwLXQKiKxjfFzSgZRngcWJzUDZi/04E0fSaF86wZgchMdvTyu+lE36DrUfvuus3bH8+xLPrhM1cTjwpzw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
@@ -13215,7 +13214,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-1.0.4.tgz",
       "integrity": "sha512-kNolMA1FXlxp2qVNbLsnP2H6S/qsYiT1su0RyiZwZ0YEitVbwHLe7ZtgIy2xa9tPv+FTvYvDoytAL3CRPjl9hQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lit/react": "^1.0.4",
@@ -13244,7 +13242,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.23.0.tgz",
       "integrity": "sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.2",
@@ -13257,14 +13254,12 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
       "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stencil/react-output-target/node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -13281,7 +13276,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -13297,7 +13291,6 @@
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-22.0.0.tgz",
       "integrity": "sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ts-morph/common": "~0.23.0",
@@ -29414,7 +29407,6 @@
       "version": "5.0.13",
       "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.13.tgz",
       "integrity": "sha512-B7JonBuAfG32I7fDouUQEogBrz3jK9gAuN1r1AaXpED6dIhtg/JwiSRhjGL7aOJwRz3HU4efowCjQBaoXiREqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
@@ -29425,7 +29417,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
       "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -29438,7 +29429,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
       "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -29495,7 +29485,6 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.3.tgz",
       "integrity": "sha512-y34oKTu+9T1fKdJE1cN9QWFWu8sx8Qa5tJOafUfMUF5Niah+yF6zlEHhWh7a0iZEcLRPIMw54bY14ajQF7xP7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domhandler": "5.0.3",
@@ -30078,7 +30067,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/inquirer": {
@@ -36789,7 +36777,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-case": {
@@ -38947,7 +38934,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
@@ -43431,14 +43417,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/style-object-to-css-string/-/style-object-to-css-string-1.1.3.tgz",
       "integrity": "sha512-bISQoUsir/qGfo7vY8rw00ia9nnyE1jvYt3zZ2jhdkcXZ6dAEi74inMzQ6On57vFI+I4Fck6wOv5UI9BEwJDgw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
       "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "style-to-object": "1.0.8"
@@ -43448,7 +43432,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
       "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.4"
@@ -48704,7 +48687,8 @@
       "version": "19.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@baloise/ds-core": "19.3.0"
+        "@baloise/ds-core": "19.3.0",
+        "@stencil/react-output-target": "^1.0.4"
       }
     },
     "packages/styles": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,6 +13,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@baloise/ds-core": "19.3.0",
-    "@stencil/react-output-target": "^1.0.4"
+    "@stencil/react-output-target": "1.0.4"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://design.baloise.dev",
   "license": "Apache-2.0",
   "dependencies": {
-    "@baloise/ds-core": "19.3.0"
+    "@baloise/ds-core": "19.3.0",
+    "@stencil/react-output-target": "^1.0.4"
   }
 }


### PR DESCRIPTION
Fix ticket [https://github.com/baloise/design-system/issues/1744](https://github.com/baloise/design-system/issues/1744)

Add the @stencil/react-output-target to the dependency list so that StencilReactComponent is defined.

StencilReactComponent is a Typescript type that is used as a wrapper Type for all the Stencil Components.

## Acceptance Criteria

- Design & Technical Review
  - [Style Guide](https://stenciljs.com/docs/style-guide)
- Document changes with a changeset
- Testing
  - Visual
  - Functional (component test)
  - Browser
    - Desktop
      - Chrome
      - Edge
      - Safari
      - Firefox
    - Tablet
      - iPad (Landscape / Portrait)
    - Mobile
      - Safari iOS
      - Chrome Preview
