### PR TITLE
:bug: fix(accordion): animation cancellation logic (#1891)

### DIFF
--- a/.changeset/sour-gorillas-cover.md
+++ b/.changeset/sour-gorillas-cover.md
@@ -1,0 +1,5 @@
+---
+'@baloise/ds-core': patch
+---
+
+**core**: fix animation cancellation logic in bal accordion

--- a/.changeset/sour-gorillas-cover.md
+++ b/.changeset/sour-gorillas-cover.md
@@ -2,4 +2,4 @@
 '@baloise/ds-core': patch
 ---
 
-**core**: fix animation cancellation logic in bal accordion
+**accordion**: fix animation cancellation logic

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -171,7 +171,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.assembleInformation.outputs.branch }}
-          token: ${{ secrets.PRE_RELEASE_GITHUB_TOKEN }}
           fetch-depth: 0
 
       - uses: ./.github/workflows/actions/setup
@@ -193,17 +192,8 @@ jobs:
 
       - name: Run Playwright tests
         run: npx nx run core:ci-e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        # run: npx nx run core:ci-e2e -- --update-snapshots
         env:
           BAL_PLAYWRIGHT_TESTING: 'true'
-
-      # - name: Commit snapshots
-      #   if: always()
-      #   uses: EndBug/add-and-commit@v9
-      #   with:
-      #     message: 'update snapshots'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.PRE_RELEASE_GITHUB_TOKEN }}
 
       - name: Upload Playwright HTML report
         if: always()

--- a/packages/core/src/components/bal-accordion/bal-accordion.tsx
+++ b/packages/core/src/components/bal-accordion/bal-accordion.tsx
@@ -27,6 +27,8 @@ export class Accordion implements ComponentInterface, BalConfigObserver, Loggabl
   private contentEl: HTMLDivElement | undefined
   private contentElWrapper: HTMLDivElement | undefined
   private currentRaf: number | undefined
+  private currentRafInner: number | undefined
+  private animationGeneration = 0
 
   @Element() el!: HTMLStencilElement
 
@@ -267,6 +269,18 @@ export class Accordion implements ComponentInterface, BalConfigObserver, Loggabl
     }
   }
 
+  private cancelAnimation = () => {
+    if (this.currentRaf !== undefined) {
+      cancelAnimationFrame(this.currentRaf)
+      this.currentRaf = undefined
+    }
+    if (this.currentRafInner !== undefined) {
+      cancelAnimationFrame(this.currentRafInner)
+      this.currentRafInner = undefined
+    }
+    this.animationGeneration++
+  }
+
   private expand = (initialUpdate = false): boolean => {
     this.active = true
 
@@ -281,21 +295,26 @@ export class Accordion implements ComponentInterface, BalConfigObserver, Loggabl
       return this.active
     }
 
-    if (this.currentRaf !== undefined) {
-      cancelAnimationFrame(this.currentRaf)
-    }
+    this.cancelAnimation()
+    const generation = this.animationGeneration
 
     if (this.shouldAnimate()) {
-      raf(() => {
+      this.currentRaf = raf(() => {
+        if (generation !== this.animationGeneration) return
+
         this.setState(AccordionState.Expanding)
         this.balWillAnimate.emit(this.active)
 
-        this.currentRaf = raf(async () => {
+        this.currentRafInner = raf(async () => {
+          if (generation !== this.animationGeneration) return
+
           const contentHeight = detailsWrapperElement.offsetHeight
           const waitForTransition = transitionEndAsync(detailsElement, 300)
           detailsElement.style.setProperty('max-height', `${contentHeight}px`)
 
           await waitForTransition
+
+          if (generation !== this.animationGeneration) return
 
           this.setState(AccordionState.Expanded)
           detailsElement.style.removeProperty('max-height')
@@ -324,22 +343,27 @@ export class Accordion implements ComponentInterface, BalConfigObserver, Loggabl
       return this.active
     }
 
-    if (this.currentRaf !== undefined) {
-      cancelAnimationFrame(this.currentRaf)
-    }
+    this.cancelAnimation()
+    const generation = this.animationGeneration
 
     if (this.shouldAnimate()) {
       this.currentRaf = raf(async () => {
+        if (generation !== this.animationGeneration) return
+
         const contentHeight = detailsElement.offsetHeight
         detailsElement.style.setProperty('max-height', `${contentHeight}px`)
 
-        raf(async () => {
+        this.currentRafInner = raf(async () => {
+          if (generation !== this.animationGeneration) return
+
           const waitForTransition = transitionEndAsync(detailsElement, 300)
 
           this.setState(AccordionState.Collapsing)
-          this.balDidAnimate.emit(this.active)
+          this.balWillAnimate.emit(this.active)
 
           await waitForTransition
+
+          if (generation !== this.animationGeneration) return
 
           this.setState(AccordionState.Collapsed)
           detailsElement.style.removeProperty('max-height')
@@ -347,7 +371,7 @@ export class Accordion implements ComponentInterface, BalConfigObserver, Loggabl
         })
       })
     } else {
-      this.balDidAnimate.emit(this.active)
+      this.balWillAnimate.emit(this.active)
       this.setState(AccordionState.Collapsed)
       this.balDidAnimate.emit(this.active)
     }


### PR DESCRIPTION
Closes #1891 

Rapidly clicking the accordion trigger caused multiple expand/collapse animations to queue up and keep animating after the user stopped clicking.

Root cause: Pending requestAnimationFrame callbacks and transitionEnd listeners from interrupted animations were never fully cancelled, so stale callbacks would mutate the accordion state mid-animation.

Before
https://github.com/user-attachments/assets/98550d69-ff5e-4e79-9804-90220b875694

After
https://github.com/user-attachments/assets/a426198b-d27f-4f45-bd03-37d823a5aeaa

