### PR TITLE
🎨 Update design tokens via Toky

### DIFF
--- a/.changeset/toky-update-next-1786179780887.md
+++ b/.changeset/toky-update-next-1786179780887.md
@@ -1,0 +1,7 @@
+---
+'@baloise/ds-tokens': minor
+---
+
+**tokens**: Created token from figma
+
+**Created:** 🌐 Global/🌈 Color/DarkFigma

--- a/.changeset/toky-update-next-1786183392750.md
+++ b/.changeset/toky-update-next-1786183392750.md
@@ -1,0 +1,8 @@
+---
+'@baloise/ds-tokens': minor
+---
+
+**tokens**: update figma tokens
+
+**Created:** 🌐 Global/🌈 Color/DarkFigmaSecond
+**Updated:** 🌐 Global/🌈 Color/DarkFigma

--- a/.changeset/toky-update-next-1786353785917.md
+++ b/.changeset/toky-update-next-1786353785917.md
@@ -1,0 +1,7 @@
+---
+'@baloise/ds-tokens': patch
+---
+
+**tokens**: timo test
+
+**Updated:** 🌐 Global/🌈 Color/DarkFigmaSecond → 🌐 Global/🌈 Color/DarkFigmaSecondTimo

--- a/packages/tokens/tokens/Base.tokens.json
+++ b/packages/tokens/tokens/Base.tokens.json
@@ -17927,6 +17927,19 @@
             "ALL_SCOPES"
           ]
         }
+      },
+      "DarkFigma": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5784254670143127,
+            0,
+            0
+          ],
+          "alpha": 1,
+          "hex": "#930000"
+        }
       }
     }
   }

--- a/packages/tokens/tokens/Base.tokens.json
+++ b/packages/tokens/tokens/Base.tokens.json
@@ -17944,7 +17944,7 @@
           "com.figma.variableId": "VariableID:38:2"
         }
       },
-      "DarkFigmaSecond": {
+      "DarkFigmaSecondTimo": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",

--- a/packages/tokens/tokens/Base.tokens.json
+++ b/packages/tokens/tokens/Base.tokens.json
@@ -17939,6 +17939,25 @@
           ],
           "alpha": 1,
           "hex": "#930000"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:38:2"
+        }
+      },
+      "DarkFigmaSecond": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.5784254670143127,
+            0,
+            0
+          ],
+          "alpha": 1,
+          "hex": "#930000"
+        },
+        "$extensions": {
+          "com.figma.variableId": "VariableID:83:3"
         }
       }
     }


### PR DESCRIPTION
Submitted via the Toky web app — no signed-in identity yet, end-user auth isn't wired up.

Created token from figma

**Created (via Figma pull):** 🌐 Global.🌈 Color.DarkFigma

---

**Additional changes — 2026-08-08T10:03:13.889Z**

update figma tokens

**Created (via Figma pull):** 🌐 Global.🌈 Color.DarkFigmaSecond
**Updated (via Figma pull):** 🌐 Global.🌈 Color.DarkFigma → 🌐 Global.🌈 Color.DarkFigma

---

**Additional changes by @hirsch88 — 2026-08-10T09:23:07.151Z**

timo test

**Updated:**
- 🌐 Global.🌈 Color.DarkFigmaSecond → 🌐 Global.🌈 Color.DarkFigmaSecondTimo (linked to Figma variable VariableID:83:3, value unchanged)