### PR TITLE
fix(ci): stop overriding checkout ref with bare branch name

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -118,7 +118,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.assembleInformation.outputs.branch }}
           fetch-depth: 2
 
       - uses: ./.github/workflows/actions/setup-environment
@@ -198,7 +197,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.assembleInformation.outputs.branch }}
           fetch-depth: 2
 
       - uses: ./.github/workflows/actions/setup-environment
@@ -244,7 +242,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.assembleInformation.outputs.branch }}
           fetch-depth: 2
 
       - uses: ./.github/workflows/actions/setup-environment


### PR DESCRIPTION
## Summary
- The `playwright`, `react`, and `angular` jobs in `continuous.yml` explicitly checked out `ref: ${{ needs.assembleInformation.outputs.branch }}`, which resolves to `github.head_ref` — just the branch name, with no owner qualifier.
- For PRs from forks (e.g. #2157), that branch only exists in the fork, not in `baloise/design-system`, so `git fetch` 404s and the job fails before any project code runs — no rerun fixes it.
- The `build` job never had this override and already checks out correctly for both same-repo and fork PRs (actions/checkout resolves the PR merge ref by default), so this drops the override in the other three jobs to match.
- `assembleInformation`'s `branch`/`action` outputs are otherwise untouched — they still feed `setup-environment`'s informational logging steps.

## Test plan
- [ ] Confirm `playwright`, `react`, and `angular` jobs check out successfully on a fork-originated PR (e.g. re-trigger CI on #2157 once merged)
- [ ] Confirm same-repo PRs and pushes to `next` still check out the correct commit