### PR TITLE
fix(ds-date): avoid Luxon/native Date timezone drift in date picker and mask

### DIFF
--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -419,7 +419,11 @@ adding a calendar-icon trigger that opens a date-picker popup. Shared vocabulary
   attribute reflection exposes.
 - **Display value** — the localized string the user sees and types in the masked
   field (e.g. `13.07.2026` for CH). Derived from DS locale config; never the
-  model value. **luxon** bridges display ⇄ model.
+  model value. Display ⇄ model conversion is native `Date` only (no Luxon) —
+  Switzerland used Local Mean Time until June 1894, and the native `Date`
+  engine and Luxon's `Intl`-based engine can disagree on the pre-1894 offset,
+  shifting the calendar day by one if a `Date` crosses between them. See the
+  comment on `nativeDateToISO` in `date.mask.ts`.
 - **Trigger** — the calendar-icon `<button>` at the end of the field. It is the
   **only** gesture that opens/toggles the popup; focusing the text input just
   places the typing cursor. `disabled` turns both off; `readonly` is display-only.

--- a/packages/core/src/components/date/date.mask.ts
+++ b/packages/core/src/components/date/date.mask.ts
@@ -47,13 +47,51 @@ function parseShortDate(raw: string, divider: string): Date | null {
   }
 
   const dt = DateTime.fromObject({ day, month, year })
-  return dt.isValid ? dt.toJSDate() : null
+  return dt.isValid ? new Date(year, month - 1, day) : null
+}
+
+// Native Date <-> ISO/display conversion, deliberately bypassing Luxon.
+//
+// Switzerland (and many other regions) used Local Mean Time with a fractional-minute
+// UTC offset until timezones were standardized in June 1894. The native `Date` engine and
+// Luxon (which relies on `Intl`) can each compute a slightly different offset for the same
+// pre-June-1894 instant. Converting a Date built by one of them (e.g. air-datepicker's native
+// `new Date(year, month, day)`) through the other (`DateTime.fromJSDate`) can therefore land
+// on the wrong side of midnight and shift the calendar day by one.
+//
+// Reading/writing a Date's own local getters/setters directly — the same engine that
+// created it — is always self-consistent, so we never let a Date object cross between
+// Luxon and native code for calendar-only values. `dateParts` is the single place that
+// extracts zero-padded day/month/year from a native Date; both ISO and display formatting
+// build on it so the two can never drift apart.
+function dateParts(date: Date): { day: string; month: string; year: string } {
+  return {
+    day: String(date.getDate()).padStart(2, '0'),
+    month: String(date.getMonth() + 1).padStart(2, '0'),
+    year: String(date.getFullYear()).padStart(4, '0'),
+  }
+}
+
+export function nativeDateToISO(date: Date): string {
+  const { year, month, day } = dateParts(date)
+  return `${year}-${month}-${day}`
+}
+
+function nativeDateToDisplay(date: Date, format: DateDisplayFormat): string {
+  const { day, month, year } = dateParts(date)
+  return [day, month, year].join(getDivider(format))
+}
+
+export function isoToNativeDate(isoValue: string): Date | null {
+  const dt = DateTime.fromISO(isoValue)
+  if (!dt.isValid) return null
+  return new Date(dt.year, dt.month - 1, dt.day)
 }
 
 export function isoToDisplay(isoValue: string | null, format: DateDisplayFormat): string {
   if (!isoValue) return ''
-  const dt = DateTime.fromISO(isoValue)
-  return dt.isValid ? dt.toFormat(format) : ''
+  const date = isoToNativeDate(isoValue)
+  return date ? nativeDateToDisplay(date, format) : ''
 }
 
 export interface DateMaskConfig {
@@ -124,8 +162,16 @@ export class DateMask {
       lazy: true,
       overwrite: true,
       autofix: true,
-      format: (date: Date) => DateTime.fromJSDate(date).toFormat(fmt),
-      parse: (str: string) => DateTime.fromFormat(str, fmt).toJSDate(),
+      // Native construction/reading only — see the comment on nativeDateToISO for why
+      // this must never round-trip through Luxon's timezone-aware conversion.
+      format: (date: Date | null) => {
+        if (!date) return ''
+        return nativeDateToDisplay(date, fmt)
+      },
+      parse: (str: string) => {
+        const [day, month, year] = str.split(getDivider(fmt)).map(Number)
+        return new Date(year, month - 1, day)
+      },
       blocks: {
         d: { mask: IMask.MaskedRange, from: 1, to: 31, maxLength: 2 },
         m: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2 },
@@ -148,8 +194,7 @@ export class DateMask {
   private getISO(): string | null {
     const typed = this.mask?.typedValue as Date | undefined
     if (!typed || isNaN(typed.getTime())) return null
-    const dt = DateTime.fromJSDate(typed)
-    return dt.isValid ? (dt.toISODate() ?? null) : null
+    return nativeDateToISO(typed)
   }
 
   setLazy(lazy: boolean) {
@@ -162,9 +207,9 @@ export class DateMask {
       this.mask.value = ''
       return
     }
-    const dt = DateTime.fromISO(isoValue)
-    if (dt.isValid) {
-      this.mask.typedValue = dt.toJSDate()
+    const date = isoToNativeDate(isoValue)
+    if (date) {
+      this.mask.typedValue = date
     }
   }
 

--- a/packages/core/src/components/date/date.picker.ts
+++ b/packages/core/src/components/date/date.picker.ts
@@ -9,10 +9,9 @@ import localeNl from 'air-datepicker/locale/nl'
 import localePl from 'air-datepicker/locale/pl'
 import localePt from 'air-datepicker/locale/pt'
 import localeSv from 'air-datepicker/locale/sv'
-import { DateTime } from 'luxon'
 import type { DsLanguage, DsRegion } from '@global'
 import { i18nDsDate } from './date.i18n'
-import { getDisplayFormat } from './date.mask'
+import { getDisplayFormat, isoToNativeDate, nativeDateToISO } from './date.mask'
 import { raf } from '@utils'
 
 export interface DatePickerConfig {
@@ -31,6 +30,13 @@ export interface DatePickerConfig {
   onClose: () => void
 }
 
+// All comparisons below rely on `iso`, `min` and `max` being zero-padded
+// YYYY-MM-DD strings (as produced by nativeDateToISO / documented on the
+// `min`/`max` props) — fixed-width ISO dates compare correctly as plain
+// strings, so no Date objects need to be constructed here. `ISO_DATE_PATTERN`
+// guards `min`/`max`, which are consumer-supplied props that may be malformed.
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
 export function checkIsWithinRange(
   iso: string,
   min: string | undefined,
@@ -39,19 +45,10 @@ export function checkIsWithinRange(
   maxYear: number | undefined,
   allowedDates: ((iso: string) => boolean) | undefined,
 ): boolean {
-  const dt = DateTime.fromISO(iso)
-  if (!dt.isValid) return false
-  const date = dt.toJSDate()
-  if (minYear !== undefined && date < new Date(minYear, 0, 1)) return false
-  if (maxYear !== undefined && date > new Date(maxYear, 11, 31)) return false
-  if (min) {
-    const minDt = DateTime.fromISO(min)
-    if (minDt.isValid && date < minDt.toJSDate()) return false
-  }
-  if (max) {
-    const maxDt = DateTime.fromISO(max)
-    if (maxDt.isValid && date > maxDt.toJSDate()) return false
-  }
+  if (minYear !== undefined && iso < `${String(minYear).padStart(4, '0')}-01-01`) return false
+  if (maxYear !== undefined && iso > `${String(maxYear).padStart(4, '0')}-12-31`) return false
+  if (min && ISO_DATE_PATTERN.test(min) && iso < min) return false
+  if (max && ISO_DATE_PATTERN.test(max) && iso > max) return false
   if (allowedDates && !allowedDates(iso)) return false
   return true
 }
@@ -93,14 +90,19 @@ export class DatePickerController {
     if (!value) {
       this.airDatepicker.clear({ silent: true })
       if (this.config.defaultDate) {
-        const dt = DateTime.fromISO(this.config.defaultDate)
-        if (dt.isValid) this.airDatepicker.setViewDate(dt.toJSDate())
+        const date = isoToNativeDate(this.config.defaultDate)
+        if (date) this.airDatepicker.setViewDate(date)
       }
       return
     }
-    const dt = DateTime.fromISO(value)
-    if (dt.isValid) {
-      this.airDatepicker.selectDate(dt.toJSDate(), { silent: true })
+    const date = isoToNativeDate(value)
+    if (date) {
+      this.airDatepicker.selectDate(date, { silent: true })
+      // selectDate only moves the calendar view itself for some navigation cases (e.g. a
+      // month change within `moveToOtherMonthsOnSelect`), not for every value change — a value
+      // typed directly into the input (e.g. 01.01.2024 -> 01.01.2025) leaves the view where it
+      // was. Explicitly navigate so the popup always opens on the month/year of the current value.
+      this.airDatepicker.setViewDate(date)
     }
   }
 
@@ -188,8 +190,7 @@ export class DatePickerController {
           return
         }
 
-        const iso = DateTime.fromJSDate(selected).toISODate()
-        if (!iso) return
+        const iso = nativeDateToISO(selected)
 
         // Update the aria-selected attribute on all cells to reflect the new selection
         this.getCells().forEach(c => {
@@ -210,8 +211,7 @@ export class DatePickerController {
           month: 'long',
           day: 'numeric',
         }).format(date)
-        const iso = DateTime.fromJSDate(date).toISODate()
-        const disabled = iso && this.config.allowedDates ? !this.config.allowedDates(iso) : false
+        const disabled = this.config.allowedDates ? !this.config.allowedDates(nativeDateToISO(date)) : false
         return { attrs: { 'aria-label': label }, disabled }
       },
     })
@@ -250,8 +250,7 @@ export class DatePickerController {
     body.addEventListener('keydown', this.handleGridKeydown as EventListener)
 
     const selected = this.airDatepicker?.selectedDates[0] ?? null
-    const defaultDateObj =
-      !selected && this.config.defaultDate ? DateTime.fromISO(this.config.defaultDate).toJSDate() : null
+    const defaultDateObj = !selected && this.config.defaultDate ? isoToNativeDate(this.config.defaultDate) : null
     this.setActiveCell(selected ?? defaultDateObj ?? this.today, focusOnDate)
   }
 
@@ -576,19 +575,13 @@ export class DatePickerController {
 
   private getMinDate(): Date | undefined {
     if (this.config.minYear !== undefined) return new Date(this.config.minYear, 0, 1)
-    if (this.config.min) {
-      const dt = DateTime.fromISO(this.config.min)
-      return dt.isValid ? dt.toJSDate() : undefined
-    }
+    if (this.config.min) return isoToNativeDate(this.config.min) ?? undefined
     return undefined
   }
 
   private getMaxDate(): Date | undefined {
     if (this.config.maxYear !== undefined) return new Date(this.config.maxYear, 11, 31)
-    if (this.config.max) {
-      const dt = DateTime.fromISO(this.config.max)
-      return dt.isValid ? dt.toJSDate() : undefined
-    }
+    if (this.config.max) return isoToNativeDate(this.config.max) ?? undefined
     return undefined
   }
 }

--- a/packages/core/src/components/date/test/date.mask.spec.ts
+++ b/packages/core/src/components/date/test/date.mask.spec.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, afterEach } from 'vitest'
+import { createDateMask, DateMask, isoToDisplay } from '../date.mask'
+
+describe('dsDate', () => {
+  describe('isoToDisplay', () => {
+    test('formats a historical date (before the June 1894 timezone standardization) unchanged', () => {
+      expect(isoToDisplay('1800-02-01', 'dd.MM.yyyy')).toBe('01.02.1800')
+    })
+
+    test('formats a modern date unchanged', () => {
+      expect(isoToDisplay('2024-01-01', 'dd.MM.yyyy')).toBe('01.01.2024')
+    })
+  })
+
+  describe('DateMask', () => {
+    let inputEl: HTMLInputElement
+    let mask: DateMask
+
+    afterEach(() => {
+      mask?.destroy()
+      inputEl?.remove()
+    })
+
+    function setup() {
+      inputEl = document.createElement('input')
+      document.body.appendChild(inputEl)
+      mask = createDateMask({
+        inputEl,
+        format: 'dd.MM.yyyy',
+        initialValue: null,
+        onAccept: () => {},
+        onComplete: () => {},
+      })
+      return mask
+    }
+
+    test('round-trips a historical date (before June 1894) through syncFromISO without shifting it', () => {
+      setup()
+      mask.syncFromISO('1800-02-01')
+      expect(inputEl.value).toBe('01.02.1800')
+    })
+
+    test('round-trips a modern date through syncFromISO', () => {
+      setup()
+      mask.syncFromISO('2024-01-01')
+      expect(inputEl.value).toBe('01.01.2024')
+    })
+
+    test('rejects a calendar-invalid date (30 February) instead of rolling it over to March', () => {
+      setup()
+      // IMask's own round-trip validation (format(parse(str)) === str) rejects this,
+      // even though our custom `parse` performs no calendar validation itself.
+      ;(mask as any).mask.value = '30.02.2026'
+
+      expect((mask as any).mask.typedValue).toBeNull()
+      expect((mask as any).getISO()).toBeNull()
+    })
+
+    test('does not fire onComplete for a calendar-invalid date', () => {
+      const completed: string[] = []
+      inputEl = document.createElement('input')
+      document.body.appendChild(inputEl)
+      mask = createDateMask({
+        inputEl,
+        format: 'dd.MM.yyyy',
+        initialValue: null,
+        onAccept: () => {},
+        onComplete: iso => completed.push(iso),
+      })
+
+      ;(mask as any).mask.value = '30.02.2026'
+
+      expect(completed).toEqual([])
+    })
+  })
+
+  describe('short year shorthand', () => {
+    let inputEl: HTMLInputElement
+    let mask: DateMask
+
+    afterEach(() => {
+      mask?.destroy()
+      inputEl?.remove()
+    })
+
+    function setup() {
+      inputEl = document.createElement('input')
+      document.body.appendChild(inputEl)
+      mask = createDateMask({
+        inputEl,
+        format: 'dd.MM.yyyy',
+        initialValue: null,
+        onAccept: () => {},
+        onComplete: () => {},
+      })
+      return mask
+    }
+
+    // 00–49 is deliberately expanded to 2000–2049, so "26" is a valid shorthand for 2026.
+    test('expandShortInput expands a two-digit year 00–49 to 20xx', () => {
+      setup()
+      inputEl.value = '01.01.26'
+
+      expect(mask.expandShortInput()).toBe(true)
+      expect(inputEl.value).toBe('01.01.2026')
+    })
+
+    // 50–99 is deliberately expanded to 1950–1999, so "76" resolves to 1976, not 2076.
+    test('expandShortInput expands a two-digit year 50–99 to 19xx', () => {
+      setup()
+      inputEl.value = '01.01.76'
+
+      expect(mask.expandShortInput()).toBe(true)
+      expect(inputEl.value).toBe('01.01.1976')
+    })
+
+    test('expandShortInput leaves a full four-digit year untouched', () => {
+      setup()
+      inputEl.value = '01.01.2026'
+
+      expect(mask.expandShortInput()).toBe(true)
+      expect(inputEl.value).toBe('01.01.2026')
+    })
+  })
+})

--- a/packages/core/src/components/date/test/date.picker.spec.ts
+++ b/packages/core/src/components/date/test/date.picker.spec.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, afterEach } from 'vitest'
+import { checkIsWithinRange, DatePickerController } from '../date.picker'
+
+describe('dsDate', () => {
+  describe('checkIsWithinRange', () => {
+    test('accepts a historical date (before June 1894) with no min/max configured', () => {
+      expect(checkIsWithinRange('1800-02-01', undefined, undefined, undefined, undefined, undefined)).toBe(true)
+    })
+  })
+
+  describe('DatePickerController', () => {
+    let host: HTMLDivElement
+    let controller: DatePickerController
+
+    afterEach(() => {
+      controller?.destroy()
+      host?.remove()
+    })
+
+    function setup(initialValue: string | null = null) {
+      host = document.createElement('div')
+      document.body.appendChild(host)
+      const shadowRoot = host.attachShadow({ mode: 'open' })
+      const popupHostEl = document.createElement('div')
+      shadowRoot.appendChild(popupHostEl)
+
+      let selected: string | null | undefined
+      controller = new DatePickerController({
+        popupHostEl,
+        shadowRoot,
+        language: 'de',
+        region: 'CH',
+        min: undefined,
+        max: undefined,
+        minYear: undefined,
+        maxYear: undefined,
+        defaultDate: undefined,
+        allowedDates: undefined,
+        initialValue,
+        onSelect: iso => {
+          selected = iso
+        },
+        onClose: () => {},
+      })
+
+      return {
+        popupHostEl,
+        getSelected: () => selected,
+        airDatepicker: () => (controller as any).airDatepicker,
+      }
+    }
+
+    // Bug: https://github.com/baloise/design-system/issues/2209
+    test('selecting a date before June 1894 does not shift it by a day', async () => {
+      const { getSelected, airDatepicker } = setup()
+
+      await airDatepicker().selectDate(new Date(1800, 1, 1))
+
+      expect(getSelected()).toBe('1800-02-01')
+    })
+
+    test('selecting a modern date resolves to the correct ISO value', async () => {
+      const { getSelected, airDatepicker } = setup()
+
+      await airDatepicker().selectDate(new Date(2024, 0, 15))
+
+      expect(getSelected()).toBe('2024-01-15')
+    })
+
+    // Bug: https://github.com/baloise/design-system/issues/2209
+    test('syncFromValue navigates the calendar view to the new value, even across a year boundary', () => {
+      const { airDatepicker } = setup('2024-01-01')
+
+      controller.syncFromValue('2025-01-01')
+
+      const viewDate = airDatepicker().viewDate as Date
+      expect(viewDate.getFullYear()).toBe(2025)
+      expect(viewDate.getMonth()).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
Closes #2209

## 📄 Description

Please include a summary of the changes made in this PR.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## ✅ Definition of Done

- [ ] Unit tests added/updated (`.spec.ts`)
- [ ] Interaction/component tests added/updated (`.component.play.ts`)
- [ ] Visual regression tests added/updated and approved (`.visual.play.ts`)
- [ ] Accessibility tests added/updated (`.a11y.play.ts`)
- [ ] Keyboard navigation and focus behavior tested
- [ ] Page Object (`packages/playwright`) up to date with component changes
- [ ] Design tokens use alias tokens only (no direct Global token references)
- [ ] Manually tested in supported browsers (desktop + mobile)
- [ ] Changeset added (`pnpm changeset`)
- [ ] Storybook documentation updated

## 📝 Checklist

- ✅ My code follows the style guidelines of this project ([STYLE_GUIDE.md](../docs/STYLE_GUIDE.md))
- 🛠️ I have performed a self-review of my own code
- ⚠️ My changes generate no new warnings or errors
