### PR TITLE
Storybook: improve React Getting Started docs

### DIFF
--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -390,10 +390,6 @@ Vite is the recommended setup for a client-side React SPA. Scaffold a TypeScript
 npm create vite@latest my-app -- --template react-ts
 ```
 
-### Create React App
-
-[Create React App](https://create-react-app.dev/) is in maintenance mode. An existing CRA app still works as a client-side SPA. The app entry is `src/index.tsx` (or `src/index.js`).
-
 ### Next.js
 
 `@baloise/ds-react` is client-only today. Import Design System components from files marked `'use client'`. Call `bootstrapDesignSystem()` at module scope in a client entry file (imported from the root layout), not inside a component function.
@@ -438,7 +434,7 @@ If the application requires a smaller payload, import only `@baloise/ds-css/css/
 
 ### bootstrapDesignSystem
 
-`bootstrapDesignSystem` initializes the Design System for a React app. Call it **once** at **module scope** in the app entry — `src/main.tsx` (Vite), `src/index.tsx` (Create React App), or a client entry imported from a Next.js root layout — **before** `createRoot(...).render(...)`. It is not a React hook; do not call it inside a component function.
+`bootstrapDesignSystem` initializes the Design System for a React app. Call it **once** at **module scope** in the app entry — `src/main.tsx` (Vite) or a client entry imported from a Next.js root layout — **before** `createRoot(...).render(...)`. It is not a React hook; do not call it inside a component function.
 
 It applies optional region, language, and brand defaults. If you omit the call, components still work with the default config.
 

--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -428,7 +428,15 @@ Import the full stylesheet once, typically in `src/main.tsx`:
 import '@baloise/ds-css/css'
 ```
 
-If the application requires a smaller payload, import only `@baloise/ds-css/css/base` and add utilities as needed. Use `@baloise/ds-css/scss/mixins` to gain access to Sass mixins, such as breakpoints.
+For a smaller payload, import the layers separately. Keep this order so tokens and resets are available before component and utility styles:
+
+```typescript
+import '@baloise/ds-css/css/base'
+import '@baloise/ds-css/css/components'
+import '@baloise/ds-css/css/utilities'
+```
+
+Use `@baloise/ds-css/scss/mixins` to gain access to Sass mixins, such as breakpoints.
 
 ## Integrate Design System
 

--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -412,11 +412,11 @@ Install the React bindings. This package includes the generated component wrappe
 
 Also install the global styles:
 
-<Code
-  language="bash"
-  noPreview
-  code={`npm install @baloise/ds-css`}
-/>
+```bash
+npm install @baloise/ds-css
+# or
+pnpm add @baloise/ds-css
+```
 
 ## Import Styles
 

--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -14,13 +14,13 @@ import {
   WarningQuote,
 } from '../../../.storybook/blocks'
 
-
-
 <Meta title="Development/Getting Started" />
 
 <Banner label="Getting Started" section="Development" />
 
-<Lead>A guide to integrate Design System Components into your application.</Lead>
+<Lead>
+  A guide to integrate Design System Components into your application.
+</Lead>
 
 All the Helvetia Design System packages are available on [NPM](https://www.npmjs.com/).
 
@@ -376,10 +376,10 @@ If you do not have a React app yet, create one with [Vite](https://vite.dev/guid
 <InfoQuote>
   **Recommendations**
 
-- Use **TypeScript**. `@baloise/ds-react` ships its own types; no extra `@types` package or `tsconfig` flags are needed.
-- Use **SCSS** as stylesheet format to access breakpoint mixins and more. A pre-built CSS bundle is also available.
-- `react` and `react-dom` **18** or **19** are required as peer dependencies.
-
+  - Use **TypeScript**. `@baloise/ds-react` ships its own types; no extra `@types` package or `tsconfig` flags are
+    needed.
+  - Use **SCSS** as stylesheet format to access breakpoint mixins and more. A pre-built CSS bundle is also available.
+  - `react` and `react-dom` **18** or **19** are required as peer dependencies.
 </InfoQuote>
 
 ### Vite
@@ -408,11 +408,19 @@ Event handlers use the `onDs*` prefix (for example `onDsClick`) and receive the 
 
 Install the React bindings. This package includes the generated component wrappers.
 
-<Code language="bash" noPreview code={`npm install @baloise/ds-react`} />
+<Code
+  language="bash"
+  noPreview
+  code={`npm install @baloise/ds-react`}
+/>
 
 Also install the global styles:
 
-<Code language="bash" noPreview code={`npm install @baloise/ds-css`} />
+<Code
+  language="bash"
+  noPreview
+  code={`npm install @baloise/ds-css`}
+/>
 
 ## Import Styles
 
@@ -436,6 +444,7 @@ It applies optional region, language, and brand defaults. If you omit the call, 
 
 ```typescript
 import { bootstrapDesignSystem } from '@baloise/ds-react'
+
 import '@baloise/ds-css/css'
 
 bootstrapDesignSystem()
@@ -458,11 +467,13 @@ Wrap the application in `DsApp` and import the components you use.
 
 **main.tsx**
 
-```typescript
+```tsx
+import { bootstrapDesignSystem } from '@baloise/ds-react'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { bootstrapDesignSystem } from '@baloise/ds-react'
-import { App } from './App'
+
+import App from './App'
+
 import '@baloise/ds-css/css'
 
 bootstrapDesignSystem()
@@ -476,18 +487,27 @@ createRoot(document.getElementById('root')!).render(
 
 **App.tsx**
 
-```typescript
+```tsx
 import { DsApp, DsAppFooter, DsButton, DsHeading } from '@baloise/ds-react'
 
 function App() {
   return (
     <DsApp className="has-sticky-footer">
-      <header>{/* Header content */}</header>
-      <main className="container">
-        <DsHeading>Hello World!</DsHeading>
-        <DsButton>Button</DsButton>
+      <header>
+        {/* Header content */}
+      </header>
+      <main className="ds-container">
+        {/* Your application content */}
+        <DsHeading>
+          Hello World!
+        </DsHeading>
+        <DsButton>
+          Button
+        </DsButton>
       </main>
-      <DsAppFooter>{/* Footer content */}</DsAppFooter>
+      <DsAppFooter>
+        {/* Footer content */}
+      </DsAppFooter>
     </DsApp>
   )
 }
@@ -506,34 +526,28 @@ export default App
 <Footer>
   <LinkCards>
     <LinkCard
-      pageTitle={'Development/Assets'}
-      description={'Guides for installing the font locally, favicons and Google maps styles.'}
+      pageTitle="Development/Assets"
+      description="Guides for installing the font locally, favicons and Google maps styles."
     />
     <LinkCard
-      pageTitle={'Development/Component'}
-      description={
-        'By using the standardized web platform APIs and Web Components the Design System achieved that the components can be used across any framework or no framework at all'
-      }
+      pageTitle="Development/Component"
+      description="By using the standardized web platform APIs and Web Components the Design System achieved that the components can be used across any framework or no framework at all"
     />
     <LinkCard
-      pageTitle={'Development/Form'}
-      description={
-        'The indispensable form controls, designed for maximum clarity. Form elements are used in combination with the CSS grid system'
-      }
+      pageTitle="Development/Form"
+      description="The indispensable form controls, designed for maximum clarity. Form elements are used in combination with the CSS grid system"
     />
     <LinkCard
-      pageTitle={'Development/Internationalization'}
-      description={'The Internationalization API of the browser provides the Design System number and date formats'}
+      pageTitle="Development/Internationalization"
+      description="The Internationalization API of the browser provides the Design System number and date formats"
     />
     <LinkCard
-      pageTitle={'Development/Theming'}
-      description={
-        "The Helvetia Design System provides a versatile foundation that can be tailored and adjusted to match a brand's identity. Customizing the appearance of Helvetia applications has never been simpler"
-      }
+      pageTitle="Development/Theming"
+      description="The Helvetia Design System provides a versatile foundation that can be tailored and adjusted to match a brand's identity. Customizing the appearance of Helvetia applications has never been simpler"
     />
     <LinkCard
-      pageTitle={'Development/Testing'}
-      description={'The Helvetia Design System provides a collection of utility functions to test the web-components'}
+      pageTitle="Development/Testing"
+      description="The Helvetia Design System provides a collection of utility functions to test the web-components"
     />
   </LinkCards>
 </Footer>

--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -369,82 +369,126 @@ Here is how you can integrate it into your project.
 
 <ReactFramework>
 
-### Installation
+## Prerequisite
 
-Install the Design System and his dependencies.
+If you do not have a React app yet, create one with [Vite](https://vite.dev/guide/) (recommended for SPAs) or [Next.js](https://nextjs.org/docs/app/getting-started).
 
+<InfoQuote>
+  **Recommendations**
+
+- Use **TypeScript**. `@baloise/ds-react` ships its own types; no extra `@types` package or `tsconfig` flags are needed.
+- Use **SCSS** as stylesheet format to access breakpoint mixins and more. A pre-built CSS bundle is also available.
+- `react` and `react-dom` **18** or **19** are required as peer dependencies.
+
+</InfoQuote>
+
+### Vite
+
+Vite is the recommended setup for a client-side React SPA. Scaffold a TypeScript app, then install the Design System as described below. The app entry is `src/main.tsx`.
+
+```bash
+npm create vite@latest my-app -- --template react-ts
 ```
-npm install @baloise/ds-react
-```
+
+### Create React App
+
+[Create React App](https://create-react-app.dev/) is in maintenance mode. An existing CRA app still works as a client-side SPA. The app entry is `src/index.tsx` (or `src/index.js`).
+
+### Next.js
+
+`@baloise/ds-react` is client-only today. Import Design System components from files marked `'use client'`. Call `bootstrapDesignSystem()` at module scope in a client entry file (imported from the root layout), not inside a component function.
+
+## TypeScript
+
+`@baloise/ds-react` publishes TypeScript declarations (`types` in `package.json` points at `dist/index.d.ts`). After installing the package, component props, events, and the `bootstrapDesignSystem` config are typed — no extra `@types/*` package or `tsconfig.json` changes are required.
+
+Event handlers use the `onDs*` prefix (for example `onDsClick`) and receive the custom event, not a React synthetic event.
+
+## Installation
+
+Install the React bindings. This package includes the generated component wrappers.
+
+<Code language="bash" noPreview code={`npm install @baloise/ds-react`} />
+
+Also install the global styles:
+
+<Code language="bash" noPreview code={`npm install @baloise/ds-css`} />
 
 ## Import Styles
 
-Component styles are automatically loaded lazily in the browser. However, CSS Utilities and other
-fundamentals need to be imported into the global stylesheet of the application. These stylesheets can be
-imported as either **SASS** or **CSS** files.
+Component styles are automatically loaded lazily in the browser. Global CSS (fonts, resets, utilities) needs to be imported into the application.
 
-Use `@baloise/ds-styles/sass/mixins` to gain access to SASS mixins, such as breakpoints.
-
-The following suggestion for importing files is recommended for greater flexibility, ensuring only necessary styles are included in the bundle.
-However, if the application requires all styles regardless of payload size, simply import the stylesheet `@baloise/ds-styles/sass/all`
-, which has all style definitions.
-
-<Code
-  language="css"
-  noPreview
-  code={`
-// SASS mixins and variables
-@forward '@baloise/ds-styles/sass/mixins';
-
-// Resets CSS for all browser
-@forward '@baloise/ds-styles/css/normalize';
-@forward '@baloise/ds-styles/css/structure';
-
-// Custom font faces
-@forward '@baloise/ds-styles/sass/font';
-
-// Core CSS, always required
-@forward '@baloise/ds-styles/css/core';
-
-// CSS utilities classes (optional)
-@forward '@baloise/ds-styles/css/utilities/background';
-@forward '@baloise/ds-styles/css/utilities/border';
-@forward '@baloise/ds-styles/css/utilities/elevation';
-@forward '@baloise/ds-styles/css/utilities/flex';
-@forward '@baloise/ds-styles/css/utilities/interaction';
-@forward '@baloise/ds-styles/css/utilities/layout';
-@forward '@baloise/ds-styles/css/utilities/sizing';
-@forward '@baloise/ds-styles/css/utilities/spacing';
-@forward '@baloise/ds-styles/css/utilities/typography';
-`}
-/>
-
-### Integrate Design System
-
-Add the `BalApp` to your root element.
+Import the full stylesheet once, typically in `src/main.tsx`:
 
 ```typescript
-import './App.scss'
-import {
-  useDesignSystem,
-  BalApp,
-  BalHeading,
-  Button,
-  Footer,
-} from '@baloise/ds-react'
+import '@baloise/ds-css/css'
+```
+
+If the application requires a smaller payload, import only `@baloise/ds-css/css/base` and add utilities as needed. Use `@baloise/ds-css/scss/mixins` to gain access to Sass mixins, such as breakpoints.
+
+## Integrate Design System
+
+### bootstrapDesignSystem
+
+`bootstrapDesignSystem` initializes the Design System for a React app. Call it **once** at **module scope** in the app entry — `src/main.tsx` (Vite), `src/index.tsx` (Create React App), or a client entry imported from a Next.js root layout — **before** `createRoot(...).render(...)`. It is not a React hook; do not call it inside a component function.
+
+It applies optional region, language, and brand defaults. If you omit the call, components still work with the default config.
+
+```typescript
+import { bootstrapDesignSystem } from '@baloise/ds-react'
+import '@baloise/ds-css/css'
+
+bootstrapDesignSystem()
+
+// or with defaults:
+bootstrapDesignSystem({
+  defaults: {
+    region: 'CH',
+    language: 'de',
+    allowedLanguages: ['de', 'fr', 'it', 'en'],
+  },
+})
+```
+
+Region and language can also be changed at runtime. See **Development/Internationalization**.
+
+### App root
+
+Wrap the application in `DsApp` and import the components you use.
+
+**main.tsx**
+
+```typescript
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { bootstrapDesignSystem } from '@baloise/ds-react'
+import { App } from './App'
+import '@baloise/ds-css/css'
+
+bootstrapDesignSystem()
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)
+```
+
+**App.tsx**
+
+```typescript
+import { DsApp, DsAppFooter, DsButton, DsHeading } from '@baloise/ds-react'
 
 function App() {
-  useDesignSystem()
-
   return (
-    <BalApp className="has-sticky-footer">
-      <header></header>
+    <DsApp className="has-sticky-footer">
+      <header>{/* Header content */}</header>
       <main className="container">
-        <BalHeading>Hello World!</BalHeading>
-        <BalButton>Button</BalButton>
+        <DsHeading>Hello World!</DsHeading>
+        <DsButton>Button</DsButton>
       </main>
-      <BalFooter></BalFooter>
-    </BalApp>
+      <DsAppFooter>{/* Footer content */}</DsAppFooter>
+    </DsApp>
   )
 }
 

--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -382,38 +382,14 @@ If you do not have a React app yet, create one with [Vite](https://vite.dev/guid
   - `react` and `react-dom` **18** or **19** are required as peer dependencies.
 </InfoQuote>
 
-### Vite
-
-Vite is the recommended setup for a client-side React SPA. Scaffold a TypeScript app, then install the Design System as described below. The app entry is `src/main.tsx`.
-
-```bash
-npm create vite@latest my-app -- --template react-ts
-```
-
-### Next.js
-
-`@baloise/ds-react` is client-only today. Import Design System components from files marked `'use client'`. Call `bootstrapDesignSystem()` at module scope in a client entry file (imported from the root layout), not inside a component function.
-
-## TypeScript
-
-`@baloise/ds-react` publishes TypeScript declarations (`types` in `package.json` points at `dist/index.d.ts`). After installing the package, component props, events, and the `bootstrapDesignSystem` config are typed — no extra `@types/*` package or `tsconfig.json` changes are required.
-
-Event handlers use the `onDs*` prefix (for example `onDsClick`) and receive the custom event, not a React synthetic event.
-
 ## Installation
 
-Install the React bindings. This package includes the generated component wrappers.
+Install the React bindings and the global styles. Both packages are required.
 
 ```bash
-npm install @baloise/ds-react
-```
-
-Also install the global styles:
-
-```bash
-npm install @baloise/ds-css
+npm install @baloise/ds-react @baloise/ds-css
 # or
-pnpm add @baloise/ds-css
+pnpm add @baloise/ds-react @baloise/ds-css
 ```
 
 ## Import Styles
@@ -442,30 +418,7 @@ Use `@baloise/ds-css/scss/mixins` to gain access to Sass mixins, such as breakpo
 
 `bootstrapDesignSystem` initializes the Design System for a React app. Call it **once** at **module scope** in the app entry — `src/main.tsx` (Vite) or a client entry imported from a Next.js root layout — **before** `createRoot(...).render(...)`. It is not a React hook; do not call it inside a component function.
 
-It applies optional region, language, and brand defaults. If you omit the call, components still work with the default config.
-
-```typescript
-import { bootstrapDesignSystem } from '@baloise/ds-react'
-
-import '@baloise/ds-css/css'
-
-bootstrapDesignSystem()
-
-// or with defaults:
-bootstrapDesignSystem({
-  defaults: {
-    region: 'CH',
-    language: 'de',
-    allowedLanguages: ['de', 'fr', 'it', 'en'],
-  },
-})
-```
-
-Region and language can also be changed at runtime. See **Development/Internationalization**.
-
-### App root
-
-Wrap the application in `DsApp` and import the components you use.
+It applies optional region, language, and brand defaults. If you omit the call, components still work with the default config. Region and language can also be changed at runtime. See **Development/Internationalization**.
 
 **main.tsx**
 
@@ -478,7 +431,13 @@ import App from './App'
 
 import '@baloise/ds-css/css'
 
-bootstrapDesignSystem()
+bootstrapDesignSystem({
+  defaults: {
+    region: 'CH',
+    language: 'de',
+    allowedLanguages: ['de', 'fr', 'it', 'en'],
+  },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -486,6 +445,10 @@ createRoot(document.getElementById('root')!).render(
   </StrictMode>,
 )
 ```
+
+### App root
+
+Wrap the application in `DsApp` and import the components you use.
 
 **App.tsx**
 
@@ -516,6 +479,26 @@ function App() {
 
 export default App
 ```
+
+## Frameworks
+
+### Vite
+
+Vite is the recommended setup for a client-side React SPA. Scaffold a TypeScript app, then install the Design System as described above. The app entry is `src/main.tsx`.
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+```
+
+### Next.js
+
+`@baloise/ds-react` is client-only today. Import Design System components from files marked `'use client'`. Call `bootstrapDesignSystem()` at module scope in a client entry file (imported from the root layout), not inside a component function.
+
+### TypeScript
+
+`@baloise/ds-react` publishes TypeScript declarations (`types` in `package.json` points at `dist/index.d.ts`). After installing the package, component props, events, and the `bootstrapDesignSystem` config are typed — no extra `@types/*` package or `tsconfig.json` changes are required.
+
+Event handlers use the `onDs*` prefix (for example `onDsClick`) and receive the custom event, not a React synthetic event.
 
 </ReactFramework>
 

--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -43,7 +43,9 @@ If you do not have an Angular app yet create one with [Angular CLI](https://angu
 <InfoQuote>
 If the projects requires translations, then install [\{TRANSLOCO\}](https://ngneat.github.io/transloco/) before the Helvetia Design System.
 
-<Code language="bash" noPreview code={`npm add -E @ngneat/transloco`} />
+```bash
+npm add -E @ngneat/transloco
+```
 
 Configure project:
 
@@ -55,7 +57,9 @@ npx ng add @ngneat/transloco
 
 Lets install the schematics to configure and add the design system to an Angular project.
 
-<Code language="bash" noPreview code={`npm add -D -E @baloise/ds-devkit`} />
+```bash
+npm add -D -E @baloise/ds-devkit
+```
 
 Install the library using Angular CLI:
 
@@ -69,7 +73,9 @@ Continue here for the manual installation guide without schematics.
 
 Let's install the latest Angular components. This package includes the Font, Token, Icon, and CSS-Utilities packages.
 
-<Code language="bash" noPreview code={`npm install @baloise/ds-angular`} />
+```bash
+npm install @baloise/ds-Angular
+```
 
 ### Import Styles
 
@@ -369,7 +375,7 @@ Here is how you can integrate it into your project.
 
 <ReactFramework>
 
-## Prerequisite
+## Installation
 
 If you do not have a React app yet, create one with [Vite](https://vite.dev/guide/) (recommended for SPAs) or [Next.js](https://nextjs.org/docs/app/getting-started).
 
@@ -382,17 +388,15 @@ If you do not have a React app yet, create one with [Vite](https://vite.dev/guid
   - `react` and `react-dom` **18** or **19** are required as peer dependencies.
 </InfoQuote>
 
-## Installation
-
 Install the React bindings and the global styles. Both packages are required.
 
 ```bash
-npm install @baloise/ds-react @baloise/ds-css
-# or
-pnpm add @baloise/ds-react @baloise/ds-css
+npm add -E @baloise/ds-react @baloise/ds-css
+// or
+pnpm add -E @baloise/ds-react @baloise/ds-css
 ```
 
-## Import Styles
+## Usage
 
 Component styles are automatically loaded lazily in the browser. Global CSS (fonts, resets, utilities) needs to be imported into the application.
 
@@ -410,9 +414,11 @@ import '@baloise/ds-css/css/components'
 import '@baloise/ds-css/css/utilities'
 ```
 
-Use `@baloise/ds-css/scss/mixins` to gain access to Sass mixins, such as breakpoints.
 
-## Integrate Design System
+<LinkCard
+  pageTitle="Development/Responsive"
+  description="Breakpoint mixins, CSS utilities, and the breakpoint service."
+/>
 
 ### bootstrapDesignSystem
 

--- a/apps/storybook/src/development/00-guides/00-getting-started.mdx
+++ b/apps/storybook/src/development/00-guides/00-getting-started.mdx
@@ -404,11 +404,9 @@ Event handlers use the `onDs*` prefix (for example `onDsClick`) and receive the 
 
 Install the React bindings. This package includes the generated component wrappers.
 
-<Code
-  language="bash"
-  noPreview
-  code={`npm install @baloise/ds-react`}
-/>
+```bash
+npm install @baloise/ds-react
+```
 
 Also install the global styles:
 


### PR DESCRIPTION
closes #2224

## Summary
- Expand the React Getting Started docs to cover Vite and Next.js setup, TypeScript (types ship with the package), and `bootstrapDesignSystem` (call once at module scope, not as a hook).
- Replace stale APIs (`useDesignSystem`, `Bal*`, `@baloise/ds-styles`) with the current ones (`Ds*`, `@baloise/ds-css`).
- Skip idiom/SSR links for now (#2218, #2219, #2220 are still open). Angular and HTML sections are unchanged.