### PR TITLE
chore: update contributing guidelines for `/cib` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Post these as a PR comment to trigger automation:
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/update-screenshots` | Regenerates visual regression snapshots and commits them to your branch. Use after intentional visual changes.                                                                                           |
 | `/snapshot`           | Publishes a snapshot npm version from your branch so you can test it in a real project before merging. See [Snapshot Versions](docs/ARCHITECTURE.md#snapshot-versions-testing-before-merge) for details. |
-| `/cib`                | Post on an **issue** to auto-create a correctly named branch for it.                                                                                                                                     |
+| `/cib`                | Post on an **issue** to auto-create a correctly named branch. The issue must have a type label (`✨ feature`, `🐛 bug`, `🔧 chore`, …); other labels such as `ready-for-agent` are skipped.             |
 
 ## Reporting Issues
 
@@ -105,13 +105,13 @@ Start any contribution (bug fix or feature) by creating a GitHub issue:
 4. Provide a clear title and description
 5. Add labels and assign to a milestone if applicable
 
-Once the issue is created, use the `/cib` command in a comment on that issue to auto-generate a branch:
+Once the issue is created, add a type label (`✨ feature`, `🐛 bug`, `🔧 chore`, `♻️ refactor`, `🧪 test`, `💥 breaking change`, `⚡️ perf`, `🚀 release`, or `🛡️ lts`) and comment `/cib` on that issue to auto-generate a branch:
 
 ```
 /cib
 ```
 
-This creates a properly named branch (e.g., `feat/button-hover-state`) and opens a PR automatically.
+This creates a properly named branch (e.g., `feat/button-hover-state`) and opens a PR automatically. Without a type label the workflow runs but skips the issue.
 
 ## Fixing a Bug
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,9 @@ Post these as a PR comment to trigger automation:
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/update-screenshots` | Regenerates visual regression snapshots and commits them to your branch. Use after intentional visual changes.                                                                                           |
 | `/snapshot`           | Publishes a snapshot npm version from your branch so you can test it in a real project before merging. See [Snapshot Versions](docs/ARCHITECTURE.md#snapshot-versions-testing-before-merge) for details. |
-| `/cib`                | Post on an **issue** to auto-create a correctly named branch. The issue must have a type label (`✨ feature`, `🐛 bug`, `🔧 chore`, …); other labels such as `ready-for-agent` are skipped.             |
+| `/cib`                | Post on an **issue** to auto-create a correctly named branch. The issue must have a type label (`✨ feature`, `🐛 bug`, `🔧 chore`, …); other labels such as `ready-for-agent` are skipped.              |
+
+`/cib` is an issue comment, not a PR comment. The type label chooses the branch prefix: `✨ feature` → `feat/…`, `🐛 bug` → `fix/…`, `🔧 chore` → `chore/…` (also `♻️ refactor`, `🧪 test`, `💥 breaking change`, `⚡️ perf`, `🚀 release`, `🛡️ lts`). Without one of those labels the workflow runs but creates nothing.
 
 ## Reporting Issues
 

--- a/apps/storybook/src/contributing.mdx
+++ b/apps/storybook/src/contributing.mdx
@@ -156,7 +156,7 @@ Post these as PR comments to trigger automation:
 
 - **`/update-screenshots`** — Regenerate visual regression snapshots after intentional changes
 - **`/snapshot`** — Publish a pre-release version for testing
-- **`/cib`** — Create a branch from an issue (post on the issue, not the PR)
+- **`/cib`** — Create a branch from an issue (post on the issue, not the PR). The issue must have a type label such as `✨ feature`, `🐛 bug`, or `🔧 chore`; other labels are skipped.
 
 See [CONTRIBUTING.md — Bot Commands](https://github.com/baloise/design-system/blob/next/CONTRIBUTING.md#bot-commands) for more.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -585,7 +585,7 @@ These commands can be posted as a PR comment to trigger workflows:
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `/update-screenshots` | Runs visual regression tests and commits updated snapshots to the PR branch. Use after intentional visual changes.           |
 | `/snapshot`           | Publishes a snapshot npm version (e.g. `1.2.3-pr123.0`) so you can install and test the PR in a real project before merging. |
-| `/cib`                | Posted on an **issue** — auto-creates a correctly named branch for that issue and posts the branch link as a comment.        |
+| `/cib`                | Posted on an **issue** — auto-creates a correctly named branch if the issue has a type label (`✨ feature`, `🐛 bug`, `🔧 chore`, …). Other labels such as `ready-for-agent` are skipped. |
 
 ## Deployment
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -581,10 +581,10 @@ All workflows live in `.github/workflows/`. Here is what runs automatically:
 
 These commands can be posted as a PR comment to trigger workflows:
 
-| Command               | Effect                                                                                                                       |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `/update-screenshots` | Runs visual regression tests and commits updated snapshots to the PR branch. Use after intentional visual changes.           |
-| `/snapshot`           | Publishes a snapshot npm version (e.g. `1.2.3-pr123.0`) so you can install and test the PR in a real project before merging. |
+| Command               | Effect                                                                                                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/update-screenshots` | Runs visual regression tests and commits updated snapshots to the PR branch. Use after intentional visual changes.                                                                        |
+| `/snapshot`           | Publishes a snapshot npm version (e.g. `1.2.3-pr123.0`) so you can install and test the PR in a real project before merging.                                                              |
 | `/cib`                | Posted on an **issue** — auto-creates a correctly named branch if the issue has a type label (`✨ feature`, `🐛 bug`, `🔧 chore`, …). Other labels such as `ready-for-agent` are skipped. |
 
 ## Deployment


### PR DESCRIPTION
- Clarified that the `/cib` command requires a type label on the issue (e.g., `✨ feature`, `🐛 bug`, `🔧 chore`) to auto-create a correctly named branch.
- Updated documentation in `CONTRIBUTING.md`, `contributing.mdx`, and `ARCHITECTURE.md` to reflect these changes.