### PR TITLE
fix(date): reject out-of-range input and update js-yaml

### DIFF
--- a/.changeset/clear-heads-show.md
+++ b/.changeset/clear-heads-show.md
@@ -1,0 +1,5 @@
+---
+'@baloise/ds-core': patch
+---
+
+**deps**: Update js-yaml to patched versions

--- a/.changeset/sparkly-cows-rescue.md
+++ b/.changeset/sparkly-cows-rescue.md
@@ -1,0 +1,5 @@
+---
+'@baloise/ds-core': patch
+---
+
+**core/date**: Prevent rejected typed dates from emitting change events

--- a/package.json
+++ b/package.json
@@ -117,8 +117,8 @@
     "_comment": "overrides below kept in sync with pnpm-workspace.yaml — required for Vercel installs. See docs/adr/0005-duplicate-pnpm-overrides.md",
     "overrides": {
       "brace-expansion@<5.0.9": "5.0.9",
-      "js-yaml@>=4.0.0 <4.3.1": "4.3.1",
-      "js-yaml@>=3.0.0 <3.15.1": "3.15.1",
+      "js-yaml@>=4.0.0 <4.3.2": "4.3.2",
+      "js-yaml@>=3.0.0 <3.15.2": "3.15.2",
       "immutable@>=5.0.0-beta.1 <5.1.8": "5.1.8",
       "sharp@<0.35.0": "0.35.3",
       "postcss@<8.5.23": "8.5.26",

--- a/packages/core/src/components/date/date.tsx
+++ b/packages/core/src/components/date/date.tsx
@@ -582,6 +582,7 @@ export class DsDate implements DsComponentInterface, FieldInterface, FormControl
           // Reject the typed date and blank the mask display — a revert, not a clear, so `value`/`dsChange`
           // are left untouched. Safe to leave `updatingFromMask` alone: the reset happens outside any
           // input event, so `onAccept` sees `event === undefined` and skips its own-clear check.
+          this.control.inputValue = this.value
           raf(() => this.dateMask?.syncFromISO(null))
           return
         }
@@ -628,7 +629,7 @@ export class DsDate implements DsComponentInterface, FieldInterface, FormControl
           ></div>
         )}
         {!this.inline && (
-          <>
+          <Fragment>
             <input
               id="input"
               part="input"
@@ -688,7 +689,7 @@ export class DsDate implements DsComponentInterface, FieldInterface, FormControl
                 ref={el => (this.popupHostEl = el as HTMLDivElement)}
               ></div>
             )}
-          </>
+          </Fragment>
         )}
       </Field>
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ catalogs:
 
 overrides:
   brace-expansion@<5.0.9: 5.0.9
-  js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  js-yaml@>=3.0.0 <3.15.1: 3.15.1
+  js-yaml@>=4.0.0 <4.3.2: 4.3.2
+  js-yaml@>=3.0.0 <3.15.2: 3.15.2
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.8
   sharp@<0.35.0: 0.35.3
   postcss@<8.5.23: 8.5.26
@@ -5997,8 +5997,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   js-yaml@5.4.1:
@@ -12097,7 +12097,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.6.3
@@ -13239,7 +13239,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,8 +37,8 @@ catalog:
 # See docs/adr/0005-duplicate-pnpm-overrides.md
 overrides:
   'brace-expansion@<5.0.9': 5.0.9
-  'js-yaml@>=4.0.0 <4.3.1': 4.3.1
-  'js-yaml@>=3.0.0 <3.15.1': 3.15.1
+  'js-yaml@>=4.0.0 <4.3.2': 4.3.2
+  'js-yaml@>=3.0.0 <3.15.2': 3.15.2
   'immutable@>=5.0.0-beta.1 <5.1.8': 5.1.8
   'sharp@<0.35.0': 0.35.3
   'postcss@<8.5.23': 8.5.26


### PR DESCRIPTION
## 📄 Description

- Prevented rejected typed dates from being committed on blur in date.tsx.
- Resolved the Fragment lint warning using explicit <Fragment>.
- Updated js-yaml overrides to patched versions 4.3.2/3.15.2 and refreshed the lockfile.
- Added separate core/date and deps changesets.
